### PR TITLE
feature: macos+aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
             asset: sling-macos-amd64
             artifact: sling
             target: x86_64-apple-darwin
+          - os: macos-latest
+            asset: sling-macos-aarch64
+            artifact: sling
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sling"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -31,5 +31,5 @@ yup-oauth2 = "5.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"
-default-features = false # Disable features which are enabled by default
+default-features = false                                            # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy"]

--- a/changelog/v0.1.0.md
+++ b/changelog/v0.1.0.md
@@ -1,6 +1,6 @@
 ## Initial release
 
- * Feature parity with `brian-dlee/s3pypkg`
- * Can `get` and install python packages from Cloud Storage provider buckets
- * Can `put` python packages into a Cloud Storage provider bucket
- * Supports `--driver`s `gs` and `s3`
+- Feature parity with `brian-dlee/s3pypkg`
+- Can `get` and install python packages from Cloud Storage provider buckets
+- Can `put` python packages into a Cloud Storage provider bucket
+- Supports `--driver`s `gs` and `s3`

--- a/changelog/v0.1.1.md
+++ b/changelog/v0.1.1.md
@@ -1,2 +1,3 @@
 ## Bugfix Release
- - Allow more than one digit in package versions
+
+- Allow more than one digit in package versions

--- a/changelog/v0.1.2.md
+++ b/changelog/v0.1.2.md
@@ -1,0 +1,3 @@
+## ARM64 Support
+
+- Build `aarch64` builds for MacOS

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ set -e
 target_arch=
 case "$(uname -m)" in
 x86_64) target_arch="amd64";;
+arm64) target_arch="aarch64";;
 *) echo "Unsupported CPU architecture: $(uname -m)" >&2; exit 1;;
 esac
 


### PR DESCRIPTION
This adds MacOS arm64 support to both the `install.sh` script and to the CI process for release.